### PR TITLE
Remove commented import's, on read-code.ts

### DIFF
--- a/src/read-code.ts
+++ b/src/read-code.ts
@@ -46,6 +46,10 @@ function matches(regex, str): { inner: string, full: string }[] {
  */
 export async function getSourceCode(fileName: string): Promise<string> {
     let code = await readFile(fileName, 'utf-8');
+    
+    const codeCommentsRegex = /(\/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*+\/)|(\/\/.*)/g;
+	code = code.replace(codeCommentsRegex, '');
+
     const importsRegex = /import "([^"]*)";/g;
     const imports = matches(importsRegex, code);
 


### PR DESCRIPTION
On Solidity files we need to comment sometimes import's for development, if the commented code is removed before it's better.
I have some examples on this link:
- https://regex101.com/r/rcknxr/3